### PR TITLE
Backend gut out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ php:
 - 5.4
 install:
 - pear install pear/PHP_CodeSniffer
-- /home/travis/.phpenv/versions/5.5/bin/composer install
+- /home/travis/.phpenv/versions/5.4/bin/composer install
 - phpenv rehash 
 script:
 - phpunit

--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@
 
 ====
 
+## Enable Eden
+
+The following documentation uses `eden()` in its example reference. Enabling this function requires an extra step as descirbed in this section which is not required if you access this package using the following.
+
+```
+Eden\Registry\Index::i();
+```
+
+When using composer, there is not an easy way to access functions from packages. As a workaround, adding this constant in your code will allow `eden()` to be available after. 
+
+```
+Eden::DECORATOR;
+```
+
+For example:
+
+```
+Eden::DECORATOR;
+
+eden()->inspect('Hello World');
+```
+
+====
+
 <a name="intro"></a>
 ## Introduction
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": ">=5.4.1",
 		"eden/core": "4.*",
-		"eden/string": "4.*",
 		"eden/array": "4.*"
     },
     "autoload": {

--- a/src/Index.php
+++ b/src/Index.php
@@ -18,7 +18,8 @@ namespace Eden\Registry;
  * @standard PSR-2
  */
 class Index extends Base
-{   
+{
+
     /**
      * Converts data to JSON format
      *
@@ -41,25 +42,25 @@ class Index extends Base
         //get args
         $args = func_get_args();
         
-		if (count($args) == 0) {
+        if (count($args) == 0) {
             return null;
         }
-		
-		$last = array_pop($args);
-		$pointer = &$this->data;
-		foreach($args as $step) {	
-			if(!isset($pointer[$step])) {
-				return null;
-			}
+        
+        $last = array_pop($args);
+        $pointer = &$this->data;
+        foreach ($args as $step) {
+            if (!isset($pointer[$step])) {
+                return null;
+            }
 
-			$pointer = &$pointer[$step];
-		}
-		
-		if(!isset($pointer[$last])) {
-			return null;
-		}
-		
-		return $pointer[$last];
+            $pointer = &$pointer[$step];
+        }
+        
+        if (!isset($pointer[$last])) {
+            return null;
+        }
+        
+        return $pointer[$last];
     }
     
     /**
@@ -84,15 +85,15 @@ class Index extends Base
      */
     public function getDot($notation, $separator = '.')
     {
-		Argument::i()
-			//argument 1 must be a string
-			->test(1, 'string')
-			//argument 2 must be a string
-			->test(2, 'string');
+        Argument::i()
+            //argument 1 must be a string
+            ->test(1, 'string')
+            //argument 2 must be a string
+            ->test(2, 'string');
 
         $args = explode($separator, $notation);
-		
-		return call_user_func_array(array($this, 'get'), $args);
+        
+        return call_user_func_array(array($this, 'get'), $args);
     }
     
     /**
@@ -105,15 +106,15 @@ class Index extends Base
      */
     public function isDot($notation, $separator = '.')
     {
-		Argument::i()
-			//argument 1 must be a string
-			->test(1, 'string')
-			//argument 2 must be a string
-			->test(2, 'string');
+        Argument::i()
+            //argument 1 must be a string
+            ->test(1, 'string')
+            //argument 2 must be a string
+            ->test(2, 'string');
 
         $args = explode($separator, $notation);
-		
-		return call_user_func_array(array($this, 'isKey'), $args);
+        
+        return call_user_func_array(array($this, 'isKey'), $args);
     }
     
     /**
@@ -131,22 +132,22 @@ class Index extends Base
         
         $last = array_pop($args);
         
-		$pointer = &$this->data;
-		foreach($args as $i => $step) {	
-			if(!isset($pointer[$step]) 
-				|| !is_array($pointer[$step])
-			) {
-				return false;
-			}
+        $pointer = &$this->data;
+        foreach ($args as $i => $step) {
+            if (!isset($pointer[$step])
+                || !is_array($pointer[$step])
+            ) {
+                return false;
+            }
 
-			$pointer = &$pointer[$step];
-		}
-		
-		if(!isset($pointer[$last])) {
-			return false;
-		}
-		
-		return true;
+            $pointer = &$pointer[$step];
+        }
+        
+        if (!isset($pointer[$last])) {
+            return false;
+        }
+        
+        return true;
     }
     
     /**
@@ -164,18 +165,18 @@ class Index extends Base
         
         $last = array_pop($args);
         
-		$pointer = &$this->data;
-		foreach($args as $i => $step) {	
-			if(!isset($pointer[$step]) 
-				|| !is_array($pointer[$step])
-			) {
-				return $this;
-			}
+        $pointer = &$this->data;
+        foreach ($args as $i => $step) {
+            if (!isset($pointer[$step])
+                || !is_array($pointer[$step])
+            ) {
+                return $this;
+            }
 
-			$pointer = &$pointer[$step];
-		}
-		
-		unset($pointer[$last]);
+            $pointer = &$pointer[$step];
+        }
+        
+        unset($pointer[$last]);
         
         return $this;
     }
@@ -192,26 +193,26 @@ class Index extends Base
     {
         //get args
         $args = func_get_args();
-		
-		if(count($args) < 2) {
-			return $this;
-		}
-		
-		$value = array_pop($args);
-		$last = array_pop($args);
         
-		$pointer = &$this->data;
-		foreach($args as $i => $step) {	
-			if(!isset($pointer[$step]) 
-				|| !is_array($pointer[$step])
-			) {
-				$pointer[$step] = array();
-			}
+        if (count($args) < 2) {
+            return $this;
+        }
+        
+        $value = array_pop($args);
+        $last = array_pop($args);
+        
+        $pointer = &$this->data;
+        foreach ($args as $i => $step) {
+            if (!isset($pointer[$step])
+                || !is_array($pointer[$step])
+            ) {
+                $pointer[$step] = array();
+            }
 
-			$pointer = &$pointer[$step];
-		}
-		
-		$pointer[$last] = $value;
+            $pointer = &$pointer[$step];
+        }
+        
+        $pointer[$last] = $value;
         
         return $this;
     }
@@ -228,16 +229,16 @@ class Index extends Base
      */
     public function setDot($notation, $value, $separator = '.')
     {
-		Argument::i()
-			//argument 1 must be a string
-			->test(1, 'string')
-			//argument 3 must be a string
-			->test(3, 'string');
+        Argument::i()
+            //argument 1 must be a string
+            ->test(1, 'string')
+            //argument 3 must be a string
+            ->test(3, 'string');
 
         $args = explode($separator, $notation);
-		
-		$args[] = $value;
-		
-		return call_user_func_array(array($this, 'set'), $args);
+        
+        $args[] = $value;
+        
+        return call_user_func_array(array($this, 'set'), $args);
     }
 }

--- a/src/Index.php
+++ b/src/Index.php
@@ -18,33 +18,7 @@ namespace Eden\Registry;
  * @standard PSR-2
  */
 class Index extends Base
-{
-    /**
-     * Construct - load data
-     *
-     * @param array
-     */
-    public function __construct($data = array())
-    {
-        //if there is more arguments or data is not an array
-        if (func_num_args() > 1 || !is_array($data)) {
-            //just get the args
-            $data = func_get_args();
-        }
-        
-        foreach ($data as $key => $value) {
-            if (!is_array($value)) {
-                continue;
-            }
-            
-            $class = get_class($this);
-            
-            $data[$key] = $this->$class($value);
-        }
-        
-        parent::__construct($data);
-    }
-    
+{   
     /**
      * Converts data to JSON format
      *
@@ -67,40 +41,25 @@ class Index extends Base
         //get args
         $args = func_get_args();
         
-        //if no args
-        if (count($args) == 0) {
-            //just return the array
-            return $this->getArray();
-        }
-        
-        //shift out the key
-        $key = array_shift($args);
-        
-        //if there is no key in our data
-        if (!isset($this->data[$key])) {
-            //return null
+		if (count($args) == 0) {
             return null;
         }
-        
-        //if our args are now empty
-        if (count($args) == 0) {
-            //if data key is a registry
-            if ($this->data[$key] instanceof Base) {
-                //just return the array
-                return $this->data[$key]->getArray();
-            }
-            
-            //return the data key
-            return $this->data[$key];
-        }
-        
-        //there are still arguments
-        if ($this->data[$key] instanceof Base) {
-            //traverse
-            return call_user_func_array(array($this->data[$key], __FUNCTION__), $args);
-        }
-        
-        return null;
+		
+		$last = array_pop($args);
+		$pointer = &$this->data;
+		foreach($args as $step) {	
+			if(!isset($pointer[$step])) {
+				return null;
+			}
+
+			$pointer = &$pointer[$step];
+		}
+		
+		if(!isset($pointer[$last])) {
+			return null;
+		}
+		
+		return $pointer[$last];
     }
     
     /**
@@ -112,17 +71,49 @@ class Index extends Base
      */
     public function getArray($modified = true)
     {
-        $array = array();
-        foreach ($this->data as $key => $data) {
-            if ($data instanceof Base) {
-                $array[$key] = $data->getArray($modified);
-                continue;
-            }
-            
-            $array[$key] = $data;
-        }
-        
-        return $array;
+        return $this->data;
+    }
+    
+    /**
+     * Gets a value given the path in the registry.
+     *
+     * @param *string $notation  Name space string notation
+     * @param string  $separator If you want to specify a different separator other than dot
+     *
+     * @return mixed
+     */
+    public function getDot($notation, $separator = '.')
+    {
+		Argument::i()
+			//argument 1 must be a string
+			->test(1, 'string')
+			//argument 2 must be a string
+			->test(2, 'string');
+
+        $args = explode($separator, $notation);
+		
+		return call_user_func_array(array($this, 'get'), $args);
+    }
+    
+    /**
+     * Checks to see if a key is set
+     *
+     * @param *string $notation  Name space string notation
+     * @param string  $separator If you want to specify a different separator other than dot
+     *
+     * @return mixed
+     */
+    public function isDot($notation, $separator = '.')
+    {
+		Argument::i()
+			//argument 1 must be a string
+			->test(1, 'string')
+			//argument 2 must be a string
+			->test(2, 'string');
+
+        $args = explode($separator, $notation);
+		
+		return call_user_func_array(array($this, 'isKey'), $args);
     }
     
     /**
@@ -138,41 +129,24 @@ class Index extends Base
             return $this;
         }
         
-        $key = array_shift($args);
+        $last = array_pop($args);
         
-        if (!isset($this->data[$key])) {
-            return false;
-        }
-        
-        if (count($args) == 0) {
-            return true;
-        }
-        
-        if ($this->data[$key] instanceof Base) {
-            return call_user_func_array(array($this->data[$key], __FUNCTION__), $args);
-        }
-        
-        return false;
-    }
-    
-    /**
-     * returns data using the ArrayAccess interface
-     *
-     * @param *scalar|null|bool $offset The key to get
-     *
-     * @return bool
-     */
-    public function offsetGet($offset)
-    {
-        if (!isset($this->data[$offset])) {
-            return null;
-        }
-        
-        if ($this->data[$offset] instanceof Base) {
-            return $this->data[$offset]->getArray();
-        }
-        
-        return $this->data[$offset];
+		$pointer = &$this->data;
+		foreach($args as $i => $step) {	
+			if(!isset($pointer[$step]) 
+				|| !is_array($pointer[$step])
+			) {
+				return false;
+			}
+
+			$pointer = &$pointer[$step];
+		}
+		
+		if(!isset($pointer[$last])) {
+			return false;
+		}
+		
+		return true;
     }
     
     /**
@@ -188,20 +162,20 @@ class Index extends Base
             return $this;
         }
         
-        $key = array_shift($args);
+        $last = array_pop($args);
         
-        if (!isset($this->data[$key])) {
-            return $this;
-        }
-        
-        if (count($args) == 0) {
-            unset($this->data[$key]);
-            return $this;
-        }
-        
-        if ($this->data[$key] instanceof Base) {
-            return call_user_func_array(array($this->data[$key], __FUNCTION__), $args);
-        }
+		$pointer = &$this->data;
+		foreach($args as $i => $step) {	
+			if(!isset($pointer[$step]) 
+				|| !is_array($pointer[$step])
+			) {
+				return $this;
+			}
+
+			$pointer = &$pointer[$step];
+		}
+		
+		unset($pointer[$last]);
         
         return $this;
     }
@@ -216,30 +190,54 @@ class Index extends Base
      */
     public function set($value = null)
     {
+        //get args
         $args = func_get_args();
+		
+		if(count($args) < 2) {
+			return $this;
+		}
+		
+		$value = array_pop($args);
+		$last = array_pop($args);
         
-        if (count($args) < 2) {
-            return $this;
-        }
-        
-        $key = array_shift($args);
-        
-        if (count($args) == 1) {
-            if (is_array($args[0])) {
-                $args[0] = self::i($args[0]);
-            }
-            
-            $this->data[$key] = $args[0];
-            
-            return $this;
-        }
-        
-        if (!isset($this->data[$key]) || !($this->data[$key] instanceof Base)) {
-            $this->data[$key] = self::i();
-        }
-        
-        call_user_func_array(array($this->data[$key], __FUNCTION__), $args);
+		$pointer = &$this->data;
+		foreach($args as $i => $step) {	
+			if(!isset($pointer[$step]) 
+				|| !is_array($pointer[$step])
+			) {
+				$pointer[$step] = array();
+			}
+
+			$pointer = &$pointer[$step];
+		}
+		
+		$pointer[$last] = $value;
         
         return $this;
+    }
+    
+    /**
+     * Creates the name space given the space
+     * and sets the value to that name space
+     *
+     * @param *string $notation  Name space string notation
+     * @param *mixed  $value     Value to set on this namespace
+     * @param string  $separator If you want to specify a different separator other than dot
+     *
+     * @return mixed
+     */
+    public function setDot($notation, $value, $separator = '.')
+    {
+		Argument::i()
+			//argument 1 must be a string
+			->test(1, 'string')
+			//argument 3 must be a string
+			->test(3, 'string');
+
+        $args = explode($separator, $notation);
+		
+		$args[] = $value;
+		
+		return call_user_func_array(array($this, 'set'), $args);
     }
 }

--- a/test/Index.php
+++ b/test/Index.php
@@ -12,17 +12,31 @@ class EdenRegistryIndexTest extends PHPUnit_Framework_TestCase
     public function testSet() 
     {
 		$registry = eden('registry') //instantiate
-		->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
-		->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
+			->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
+			->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
 		
 		$this->assertInstanceOf('Eden\\Registry\\Base', $registry);
+		
+		//overriding
+		$results = $registry
+			->set('path', 'to', 'value1', 'value2', 123)
+			->getArray();
+		
+		$this->assertEquals(123, $results['path']['to']['value1']['value2']);
+		
+		//overriding
+		$results = $registry
+			->set('path', 123)
+			->getArray();
+		
+		$this->assertEquals(123, $results['path']);
 	}
 	
 	public function testGet() 
     {
 		$registry = eden('registry') //instantiate
-		->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
-		->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
+			->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
+			->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
 		
 		$value1 = $registry->get('path', 'to', 'value1'); //--> 123
 		$value2 = $registry->get('path', 'to', 'value2'); //--> 456
@@ -37,5 +51,63 @@ class EdenRegistryIndexTest extends PHPUnit_Framework_TestCase
 		$registry['name'] = 'value';
 		
 		$this->assertEquals('value', $registry['name']);
+		
+		$this->assertEquals(123, $registry['path']['to']['value1']);
+		$this->assertTrue(!isset($registry['path']['to']['value3']));
+		$this->assertNull($registry->get('path', 'to', 'value3', 'and', 'beyond'));
+		$this->assertEquals(123, $registry->path['to']['value1']);
+	}
+	
+	public function testRemove()
+	{
+		$registry = eden('registry') //instantiate
+			->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
+			->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
+		
+		$registry->remove('path', 'to', 'value1');
+		
+		$this->assertTrue(!isset($registry['path']['to']['value1']));
+		$this->assertNull($registry->get('path', 'to', 'value1'));
+		
+		$this->assertEquals('{"path":{"to":{"value2":456}}}', (string) $registry);
+	}
+	
+	public function testIsKey()
+	{
+		$registry = eden('registry') //instantiate
+			->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
+			->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
+		
+		$this->assertTrue($registry->isKey('path', 'to', 'value1'));
+		$this->assertTrue($registry->isKey('path', 'to', 'value2'));
+		$this->assertTrue($registry->isKey('path', 'to'));
+		$this->assertFalse($registry->isKey('path', 'to', 'value3'));
+	}
+	
+	public function testIsDot()
+	{
+		$registry = eden('registry') //instantiate
+			->set('path', 'to', 'value1', 123)   //set path 'path','to', 'value' to 123
+			->set('path', 'to', 'value2', 456);  //set path 'path','to', 'value' to 456
+		
+		$this->assertTrue($registry->isDot('path.to.value1'));
+		$this->assertTrue($registry->isDot('path-to-value2', '-'));
+		$this->assertTrue($registry->isDot('path.to'));
+		$this->assertFalse($registry->isDot('path.to.value3'));
+		$this->assertFalse($registry->isDot('path-to-value3'));
+	}
+	
+	public function testDot()
+	{
+		$registry = eden('registry')
+			->setDot('path.to.value1', 123)
+			->setDot('path-to-value2', 456, '-')
+			->setDot('path-to-value3', 789);
+			
+		$results = $registry->getDot('path.to');
+		
+		$this->assertEquals(123, $results['value1']);
+		$this->assertEquals(456, $results['value2']);
+		$this->assertTrue(!isset($results['value3']));
 	}
 }


### PR DESCRIPTION
- Removed Nested Object Concept because it was too heavy when dealing
  with a lot of data
- Favoured References and pointers over recursive calls
- Added `getDot`, `setDot` and `isDot`
- Updated test suites
- still backwards compatible
